### PR TITLE
Properly quote article URLs

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,7 +38,7 @@ function loadNews() {
 
   $.getJSON(url + apiKey, function(data) {
     var titles = data.articles.map(function(articles) {
-      return "<a href=" + articles.url + ">" + articles.title + "</a>";
+      return "<a href='" + articles.url + "'>" + articles.title + "</a>";
     });
 
     news.html(titles.join("<br><br>"));


### PR DESCRIPTION
This PR fixes the issue with improperly formatted `a` tags.